### PR TITLE
og:typeの出力変更

### DIFF
--- a/class/output.php
+++ b/class/output.php
@@ -585,7 +585,7 @@ class SSP_Output {
 	 * @return string : The og:type.
 	 */
 	private static function generate_og_type() {
-		$og_type = is_singular() ? 'article' : 'website';
+		$og_type = is_front_page() ? 'website' : 'article';
 		return apply_filters( 'ssp_output_og_type', $og_type );
 	}
 


### PR DESCRIPTION
このプラグインをよく使わせていただいているのですが、トップページで `og:type` に `article` が出力されているのが気になりました。
トップページでは `website`、それ以外のページでは `article` を出力するのが一般的かと思うので、変更いたしました。