### PR TITLE
add hook for override og-image

### DIFF
--- a/class/output.php
+++ b/class/output.php
@@ -146,7 +146,7 @@ class SSP_Output {
 		// Generate other ogp tags
 		self::$og_locale = apply_filters( 'ssp_output_og_locale', Output_Helper::get_valid_og_locale() );
 		self::$og_type   = self::generate_og_type();
-		self::$og_image  = self::generate_og_image();
+		self::$og_image  = apply_filters( 'ssp_output_og_image', self::generate_og_image() );
 
 		// Generate SNS ogp tags
 		if ( SSP_Data::$ogp['fb_active'] ) {


### PR DESCRIPTION
add filter hook 'ssp_output_og_image'

@ddryo 

デフォルトの og:image をカスタム投稿タイプごとに変更したいという要望があり、フィルターフックを追加いただければ上書きが可能になると思いプルリクを作成しました。
自分のローカルでのテストではこのフックの追加で希望の動作が可能になり、サイト全体のデフォルトの og:image はそのまま引き続き有効になることも確認しましたので、もし可能であればマージしていただけると大変嬉しいです！
